### PR TITLE
Allow different user ids for shops in a multishop environment

### DIFF
--- a/inc/Basemodule.php
+++ b/inc/Basemodule.php
@@ -74,7 +74,7 @@ class PostFinanceCheckoutBasemodule
     const TOTAL_MODE_WITHOUT_SHIPPING_INC = 4;
 
     const TOTAL_MODE_WITHOUT_SHIPPING_EXC = 5;
-        
+
     private static $recordMailMessages = false;
 
     private static $recordedMailMessages = array();
@@ -138,35 +138,35 @@ class PostFinanceCheckoutBasemodule
     {
         return Configuration::updateGlobalValue(self::CK_MAIL, true) &&
             Configuration::updateGlobalValue(self::CK_INVOICE, true) &&
-			Configuration::updateGlobalValue(self::CK_PACKING_SLIP, true) &&
-			Configuration::updateGlobalValue(self::CK_LINE_ITEM_CONSISTENCY, true);
+            Configuration::updateGlobalValue(self::CK_PACKING_SLIP, true) &&
+            Configuration::updateGlobalValue(self::CK_LINE_ITEM_CONSISTENCY, true);
     }
 
     public static function uninstallConfigurationValues()
     {
         return
-			Configuration::deleteByName(self::CK_USER_ID) &&
-			Configuration::deleteByName(self::CK_APP_KEY) &&
+            Configuration::deleteByName(self::CK_USER_ID) &&
+            Configuration::deleteByName(self::CK_APP_KEY) &&
             Configuration::deleteByName(self::CK_SPACE_ID) &&
-			Configuration::deleteByName(self::CK_SPACE_VIEW_ID) &&
+            Configuration::deleteByName(self::CK_SPACE_VIEW_ID) &&
             Configuration::deleteByName(self::CK_MAIL) &&
-			Configuration::deleteByName(self::CK_INVOICE) &&
+            Configuration::deleteByName(self::CK_INVOICE) &&
             Configuration::deleteByName(self::CK_PACKING_SLIP) &&
-			Configuration::deleteByName(self::CK_LINE_ITEM_CONSISTENCY) &&
-			Configuration::deleteByName(self::CK_FEE_ITEM) &&
+            Configuration::deleteByName(self::CK_LINE_ITEM_CONSISTENCY) &&
+            Configuration::deleteByName(self::CK_FEE_ITEM) &&
             Configuration::deleteByName(self::CK_SURCHARGE_ITEM) &&
-			Configuration::deleteByName(self::CK_SURCHARGE_TAX) &&
+            Configuration::deleteByName(self::CK_SURCHARGE_TAX) &&
             Configuration::deleteByName(self::CK_SURCHARGE_AMOUNT) &&
             Configuration::deleteByName(self::CK_SURCHARGE_TOTAL) &&
-			Configuration::deleteByName(self::CK_SURCHARGE_BASE) &&
+            Configuration::deleteByName(self::CK_SURCHARGE_BASE) &&
             Configuration::deleteByName(PostFinanceCheckoutServiceManualtask::CONFIG_KEY) &&
             Configuration::deleteByName(self::CK_STATUS_FAILED) &&
             Configuration::deleteByName(self::CK_STATUS_AUTHORIZED) &&
             Configuration::deleteByName(self::CK_STATUS_VOIDED) &&
-			Configuration::deleteByName(self::CK_STATUS_COMPLETED) &&
-			Configuration::deleteByName(self::CK_STATUS_MANUAL) &&
+            Configuration::deleteByName(self::CK_STATUS_COMPLETED) &&
+            Configuration::deleteByName(self::CK_STATUS_MANUAL) &&
             Configuration::deleteByName(self::CK_STATUS_DECLINED) &&
-			Configuration::deleteByName(self::CK_STATUS_FULFILL);
+            Configuration::deleteByName(self::CK_STATUS_FULFILL);
     }
 
 
@@ -361,7 +361,7 @@ class PostFinanceCheckoutBasemodule
         if (Tools::isSubmit('submit' . $module->name . '_fee_item')) {
             if (! $module->getContext()->shop->isFeatureActive() || $module->getContext()->shop->getContext() == Shop::CONTEXT_SHOP) {
                 Configuration::updateValue(self::CK_LINE_ITEM_CONSISTENCY, Tools::getValue(self::CK_LINE_ITEM_CONSISTENCY));
-				Configuration::updateValue(self::CK_FEE_ITEM, Tools::getValue(self::CK_FEE_ITEM));
+                Configuration::updateValue(self::CK_FEE_ITEM, Tools::getValue(self::CK_FEE_ITEM));
                 Configuration::updateValue(self::CK_SURCHARGE_ITEM, Tools::getValue(self::CK_SURCHARGE_ITEM));
                 Configuration::updateValue(self::CK_SURCHARGE_TAX, Tools::getValue(self::CK_SURCHARGE_TAX));
                 Configuration::updateValue(self::CK_SURCHARGE_AMOUNT, Tools::getValue(self::CK_SURCHARGE_AMOUNT));
@@ -740,29 +740,29 @@ class PostFinanceCheckoutBasemodule
                 ),
                 'lang' => false
             ),
-			array(
-				'type' => 'switch',
-				'label' => $module->l('Line item consistency', 'basemodule'),
-				'name' => self::CK_LINE_ITEM_CONSISTENCY,
-				'desc' => $module->l(
-					'If this option is enabled line item totals will always match the order total.',
-					'basemodule'
-				),
-				'is_bool' => true,
-				'values' => array(
-					array(
-						'id' => 'active_on',
-						'value' => 1,
-						'label' => $module->l('Allow', 'basemodule')
-					),
-					array(
-						'id' => 'active_off',
-						'value' => 0,
-						'label' => $module->l('Disallow', 'basemodule')
-					)
-				),
-				'lang' => false
-			),
+            array(
+                'type' => 'switch',
+                'label' => $module->l('Line item consistency', 'basemodule'),
+                'name' => self::CK_LINE_ITEM_CONSISTENCY,
+                'desc' => $module->l(
+                    'If this option is enabled line item totals will always match the order total.',
+                    'basemodule'
+                ),
+                'is_bool' => true,
+                'values' => array(
+                    array(
+                        'id' => 'active_on',
+                        'value' => 1,
+                        'label' => $module->l('Allow', 'basemodule')
+                    ),
+                    array(
+                        'id' => 'active_off',
+                        'value' => 0,
+                        'label' => $module->l('Disallow', 'basemodule')
+                    )
+                ),
+                'lang' => false
+            ),
             array(
                 'type' => 'text',
                 'label' => $module->l('Surcharge Amount', 'basemodule'),
@@ -855,7 +855,7 @@ class PostFinanceCheckoutBasemodule
     {
         $values = array();
         if (! $module->getContext()->shop->isFeatureActive() || $module->getContext()->shop->getContext() == Shop::CONTEXT_SHOP) {
-			$values[self::CK_FEE_ITEM] = (int) Configuration::get(self::CK_FEE_ITEM);
+            $values[self::CK_FEE_ITEM] = (int) Configuration::get(self::CK_FEE_ITEM);
             $values[self::CK_LINE_ITEM_CONSISTENCY] = (int) Configuration::get(self::CK_LINE_ITEM_CONSISTENCY);
             $values[self::CK_SURCHARGE_ITEM] = (int) Configuration::get(self::CK_SURCHARGE_ITEM);
             $values[self::CK_SURCHARGE_TAX] = (int) Configuration::get(self::CK_SURCHARGE_TAX);
@@ -1373,7 +1373,7 @@ class PostFinanceCheckoutBasemodule
                     $duplicateMessage->save();
                 }
 
-                
+
                 if (strpos($payment_method, "postfinancecheckout_") === 0) {
                     $id = Tools::substr($payment_method, strpos($payment_method, "_") + 1);
                     $methodConfiguration = new PostFinanceCheckoutModelMethodconfiguration($id);
@@ -1483,7 +1483,7 @@ class PostFinanceCheckoutBasemodule
 
     public static function hookActionProductCancel(PostFinanceCheckout $module, $params)
     {
-        // check version too here to only run on > 1.7.7 for now 
+        // check version too here to only run on > 1.7.7 for now
         // as there is some overlap in functionality with some previous versions 1.7+
         if ($params['action'] === CancellationActionType::PARTIAL_REFUND && version_compare(_PS_VERSION_, '1.7.7', '>=')) {
 
@@ -1500,7 +1500,7 @@ class PostFinanceCheckoutBasemodule
             if ($strategy->isVoucherOnlyPostFinanceCheckout($order, $refundParameters)) {
                 return;
             }
-            
+
             // need to manually set this here as it's expected downstream
             $refundParameters['partialRefund'] = true;
 
@@ -2267,18 +2267,18 @@ class PostFinanceCheckoutBasemodule
             PostFinanceCheckoutHelper::commitDBTransaction();
         }
     }
-    
-    
+
+
     public static function hookDisplayTop(PostFinanceCheckout $module, $params)
     {
         return self::getCronJobItem($module);
     }
-    
+
     public static function getCronJobItem(PostFinanceCheckout $module)
     {
         PostFinanceCheckoutCron::cleanUpHangingCrons();
         PostFinanceCheckoutCron::insertNewPendingCron();
-        
+
         $currentToken = PostFinanceCheckoutCron::getCurrentSecurityTokenForPendingCron();
         if ($currentToken) {
             $url = $module->getContext()->link->getModuleLink(
@@ -2292,8 +2292,8 @@ class PostFinanceCheckoutBasemodule
             return '<img src="' . $url . '" style="display:none" />';
         }
     }
-    
-    
+
+
     public static function hookPostFinanceCheckoutCron($params)
     {
         $tasks = array();

--- a/inc/Basemodule.php
+++ b/inc/Basemodule.php
@@ -245,9 +245,10 @@ class PostFinanceCheckoutBasemodule
             $refresh = true;
             if ($module->getContext()->shop->isFeatureActive()) {
                 if ($module->getContext()->shop->getContext() == Shop::CONTEXT_ALL) {
-                    Configuration::updateGlobalValue(self::CK_USER_ID, Tools::getValue(self::CK_USER_ID));
-                    Configuration::updateGlobalValue(self::CK_APP_KEY, Tools::getValue(self::CK_APP_KEY));
-                    $output .= $module->displayConfirmation($module->l('Settings updated', 'basemodule'));
+                    $refresh = false;
+                    $output .= $module->displayError(
+                        $module->l('You can not store the configuration for All Shops.', 'basemodule')
+                    );
                 } elseif ($module->getContext()->shop->getContext() == Shop::CONTEXT_SHOP) {
                     foreach ($module->getConfigurationKeys() as $key) {
                         Configuration::updateValue($key, Tools::getValue($key));
@@ -260,8 +261,6 @@ class PostFinanceCheckoutBasemodule
                     );
                 }
             } else {
-                Configuration::updateGlobalValue(self::CK_USER_ID, Tools::getValue(self::CK_USER_ID));
-                Configuration::updateGlobalValue(self::CK_APP_KEY, Tools::getValue(self::CK_APP_KEY));
                 foreach ($module->getConfigurationKeys() as $key) {
                     Configuration::updateValue($key, Tools::getValue($key));
                 }
@@ -280,6 +279,8 @@ class PostFinanceCheckoutBasemodule
     public static function getConfigurationKeys()
     {
         return array(
+            self::CK_USER_ID,
+            self::CK_APP_KEY,
             self::CK_SPACE_ID,
             self::CK_SPACE_VIEW_ID,
             self::CK_MAIL,
@@ -309,10 +310,13 @@ class PostFinanceCheckoutBasemodule
             $refresh = true;
             if ($module->getContext()->shop->isFeatureActive()) {
                 if ($module->getContext()->shop->getContext() == Shop::CONTEXT_ALL) {
-                    Configuration::updateGlobalValue(self::CK_USER_ID, Tools::getValue(self::CK_USER_ID));
-                    Configuration::updateGlobalValue(self::CK_APP_KEY, Tools::getValue(self::CK_APP_KEY));
-                    $output .= $module->displayConfirmation($module->l('Settings updated', 'basemodule'));
+                    $refresh = false;
+                    $output .= $module->displayError(
+                        $module->l('You can not store the configuration for All Shops.', 'basemodule')
+                    );
                 } elseif ($module->getContext()->shop->getContext() == Shop::CONTEXT_SHOP) {
+                    Configuration::updateValue(self::CK_USER_ID, Tools::getValue(self::CK_USER_ID));
+                    Configuration::updateValue(self::CK_APP_KEY, Tools::getValue(self::CK_APP_KEY));
                     Configuration::updateValue(self::CK_SPACE_ID, Tools::getValue(self::CK_SPACE_ID));
                     Configuration::updateValue(self::CK_SPACE_VIEW_ID, Tools::getValue(self::CK_SPACE_VIEW_ID));
                     $output .= $module->displayConfirmation($module->l('Settings updated', 'basemodule'));
@@ -323,8 +327,8 @@ class PostFinanceCheckoutBasemodule
                     );
                 }
             } else {
-                Configuration::updateGlobalValue(self::CK_USER_ID, Tools::getValue(self::CK_USER_ID));
-                Configuration::updateGlobalValue(self::CK_APP_KEY, Tools::getValue(self::CK_APP_KEY));
+                Configuration::updateValue(self::CK_USER_ID, Tools::getValue(self::CK_USER_ID));
+                Configuration::updateValue(self::CK_APP_KEY, Tools::getValue(self::CK_APP_KEY));
                 Configuration::updateValue(self::CK_SPACE_ID, Tools::getValue(self::CK_SPACE_ID));
                 Configuration::updateValue(self::CK_SPACE_VIEW_ID, Tools::getValue(self::CK_SPACE_VIEW_ID));
                 $output .= $module->displayConfirmation($module->l('Settings updated', 'basemodule'));
@@ -483,7 +487,7 @@ class PostFinanceCheckoutBasemodule
             'type' => 'html',
             'name' => 'IGNORE',
             'col' => 3,
-            'html_content' => '<b>' . $module->l('The User Id needs to be configured globally.', 'basemodule') . '</b>'
+            'html_content' => '<b>' . $module->l('The User Id needs to be configured per shop.', 'basemodule') . '</b>'
         );
 
         $userPwInfo = array(
@@ -491,7 +495,7 @@ class PostFinanceCheckoutBasemodule
             'name' => 'IGNORE',
             'col' => 3,
             'html_content' => '<b>' .
-            $module->l('The Authentication Key needs to be configured globally.', 'basemodule') . '</b>'
+            $module->l('The Authentication Key needs to be configured per shop.', 'basemodule') . '</b>'
         );
 
         $spaceIdConfig = array(
@@ -530,14 +534,14 @@ class PostFinanceCheckoutBasemodule
             if ($module->getContext()->shop->getContext() == Shop::CONTEXT_ALL) {
                 $generalInputs = array(
                     $spaceIdInfo,
-                    $userIdConfig,
-                    $userPwConfig
+                    $userIdInfo,
+                    $userPwInfo
                 );
             } elseif ($module->getContext()->shop->getContext() == Shop::CONTEXT_SHOP) {
                 $generalInputs = array(
                     $spaceIdConfig,
-                    $userIdInfo,
-                    $userPwInfo
+                    $userIdConfig,
+                    $userPwConfig
                 );
                 array_unshift(
                     $buttons,
@@ -592,20 +596,10 @@ class PostFinanceCheckoutBasemodule
     public static function getApplicationConfigValues(PostFinanceCheckout $module)
     {
         $values = array();
-        if ($module->getContext()->shop->isFeatureActive()) {
-            if ($module->getContext()->shop->getContext() == Shop::CONTEXT_ALL) {
-                $values[self::CK_USER_ID] = Configuration::getGlobalValue(self::CK_USER_ID);
-                $values[self::CK_APP_KEY] = Configuration::getGlobalValue(self::CK_APP_KEY);
-            } elseif ($module->getContext()->shop->getContext() == Shop::CONTEXT_SHOP) {
-                $values[self::CK_SPACE_ID] = Configuration::get(self::CK_SPACE_ID);
-                $values[self::CK_SPACE_VIEW_ID] = Configuration::get(self::CK_SPACE_VIEW_ID);
-            }
-        } else {
-            $values[self::CK_USER_ID] = Configuration::getGlobalValue(self::CK_USER_ID);
-            $values[self::CK_APP_KEY] = Configuration::getGlobalValue(self::CK_APP_KEY);
-            $values[self::CK_SPACE_ID] = Configuration::get(self::CK_SPACE_ID);
-            $values[self::CK_SPACE_VIEW_ID] = Configuration::get(self::CK_SPACE_VIEW_ID);
-        }
+        $values[self::CK_USER_ID] = Configuration::get(self::CK_USER_ID);
+        $values[self::CK_APP_KEY] = Configuration::get(self::CK_APP_KEY);
+        $values[self::CK_SPACE_ID] = Configuration::get(self::CK_SPACE_ID);
+        $values[self::CK_SPACE_VIEW_ID] = Configuration::get(self::CK_SPACE_VIEW_ID);
         return $values;
     }
 

--- a/inc/Helper.php
+++ b/inc/Helper.php
@@ -36,8 +36,8 @@ class PostFinanceCheckoutHelper
     public static function getApiClient()
     {
         if (self::$apiClient === null) {
-            $userId = Configuration::getGlobalValue(PostFinanceCheckoutBasemodule::CK_USER_ID);
-            $userKey = Configuration::getGlobalValue(PostFinanceCheckoutBasemodule::CK_APP_KEY);
+            $userId = Configuration::get(PostFinanceCheckoutBasemodule::CK_USER_ID);
+            $userKey = Configuration::get(PostFinanceCheckoutBasemodule::CK_APP_KEY);
             if (! empty($userId) && ! empty($userKey)) {
                 self::$apiClient = new \PostFinanceCheckout\Sdk\ApiClient($userId, $userKey);
                 self::$apiClient->setBasePath(self::getBaseGatewayUrl() . '/api');

--- a/inc/Helper.php
+++ b/inc/Helper.php
@@ -167,36 +167,36 @@ class PostFinanceCheckoutHelper
     /**
      * Cleans the given line items by ensuring uniqueness and introducing adjustment line items if necessary.
      *
-	 * @param \PostFinanceCheckout\Sdk\Model\LineItemCreate[] $lineItems
-	 * @param float $expectedSum
-	 * @param string $currencyCode
-	 *
-	 * @return \PostFinanceCheckout\Sdk\Model\LineItemCreate[]
-	 * @throws \PostFinanceCheckoutExceptionInvalidtransactionamount
-	 */
+     * @param \PostFinanceCheckout\Sdk\Model\LineItemCreate[] $lineItems
+     * @param float $expectedSum
+     * @param string $currencyCode
+     *
+     * @return \PostFinanceCheckout\Sdk\Model\LineItemCreate[]
+     * @throws \PostFinanceCheckoutExceptionInvalidtransactionamount
+     */
     public static function cleanupLineItems(array &$lineItems, $expectedSum, $currencyCode)
     {
         $effectiveSum = self::roundAmount(self::getTotalAmountIncludingTax($lineItems), $currencyCode);
         $roundedExpected = self::roundAmount($expectedSum, $currencyCode);
         $diff = $roundedExpected - $effectiveSum;
         if ($diff != 0) {
-        	if((int) Configuration::getGlobalValue(PostFinanceCheckoutBasemodule::CK_LINE_ITEM_CONSISTENCY)){
-				throw new PostFinanceCheckoutExceptionInvalidtransactionamount($effectiveSum, $roundedExpected);
-			}else{
-				$diffAmount = self::roundAmount($diff, $currencyCode);
-				$lineItem = (new \PostFinanceCheckout\Sdk\Model\LineItemCreate())
-					->setName(self::getModuleInstance()->l('Adjustment LineItem', 'helper'))
-					->setUniqueId('Adjustment-Line-Item')
-					->setSku('Adjustment-Line-Item')
-					->setQuantity(1);
-				/** @noinspection PhpParamsInspection */
-				$lineItem->setAmountIncludingTax($diffAmount)->setType(($diff > 0) ? \PostFinanceCheckout\Sdk\Model\LineItemType::FEE : \PostFinanceCheckout\Sdk\Model\LineItemType::DISCOUNT);
+            if((int) Configuration::getGlobalValue(PostFinanceCheckoutBasemodule::CK_LINE_ITEM_CONSISTENCY)){
+                throw new PostFinanceCheckoutExceptionInvalidtransactionamount($effectiveSum, $roundedExpected);
+            }else{
+                $diffAmount = self::roundAmount($diff, $currencyCode);
+                $lineItem = (new \PostFinanceCheckout\Sdk\Model\LineItemCreate())
+                    ->setName(self::getModuleInstance()->l('Adjustment LineItem', 'helper'))
+                    ->setUniqueId('Adjustment-Line-Item')
+                    ->setSku('Adjustment-Line-Item')
+                    ->setQuantity(1);
+                /** @noinspection PhpParamsInspection */
+                $lineItem->setAmountIncludingTax($diffAmount)->setType(($diff > 0) ? \PostFinanceCheckout\Sdk\Model\LineItemType::FEE : \PostFinanceCheckout\Sdk\Model\LineItemType::DISCOUNT);
 
-				if (!$lineItem->valid()) {
-					throw new \Exception('Adjustment LineItem payload invalid:' . json_encode($lineItem->listInvalidProperties()));
-				}
-				$lineItems[] = $lineItem;
-			}
+                if (!$lineItem->valid()) {
+                    throw new \Exception('Adjustment LineItem payload invalid:' . json_encode($lineItem->listInvalidProperties()));
+                }
+                $lineItems[] = $lineItem;
+            }
         }
 
         return self::ensureUniqueIds($lineItems);
@@ -206,10 +206,10 @@ class PostFinanceCheckoutHelper
      * Ensures uniqueness of the line items.
      *
      * @param \PostFinanceCheckout\Sdk\Model\LineItemCreate[] $lineItems
-	 *
+     *
      * @return \PostFinanceCheckout\Sdk\Model\LineItemCreate[]
-	 * @throws \Exception
-	 */
+     * @throws \Exception
+     */
     public static function ensureUniqueIds(array $lineItems)
     {
         $uniqueIds = array();
@@ -470,9 +470,9 @@ class PostFinanceCheckoutHelper
      * Sorts an array of PostFinanceCheckoutModelMethodconfiguration by their sort order
      *
      * @param PostFinanceCheckoutModelMethodconfiguration[] $configurations
-	 *
-	 * @return array
-	 */
+     *
+     * @return array
+     */
     public static function sortMethodConfiguration(array $configurations)
     {
         usort(
@@ -649,10 +649,10 @@ class PostFinanceCheckoutHelper
 
         return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
     }
-    
+
     public static function getMaxExecutionTime() {
         $maxExecutionTime = ini_get('max_execution_time');
-        
+
         // Returns the default value, in case the ini_get fails.
         if ($maxExecutionTime === null || empty($maxExecutionTime) || $maxExecutionTime < 0) {
             return 30;


### PR DESCRIPTION
## Problem:
Postfinance Checkout configures the PFC_USER_ID and PFC_APP_KEY at the `All shops`-context only. It is not possible to configure different USER_ID for two separate shops in a multishop environment.
Even though in most installations with mutlishop features enabled, all shops belong to the same owner, this may not always be the case. In our case, we provide a prestashop hosting on a shared Prestashop install for our commercial partner which are independent libraries. Therefore those that use Postfinance Checkout all have different USER_IDs.

## Solution:
Configure PFC_USER_ID and PFC_APP_KEY at the shop level.
This allow us to recommend the use of Postfinance Checkout for our partners, while it does not affect the use for your other customers.

Thank you to consider to incorporate this PR into your code base.
With best regards.